### PR TITLE
Load manufacturers from JSON

### DIFF
--- a/src/routes/api/+server.js
+++ b/src/routes/api/+server.js
@@ -1,36 +1,21 @@
+import manufacturers from "./manufacturers.json";
 
 export function isSpcProduct(barcode) {
-    let returnStrings = {
+    const returnStrings = {
         manu: null,
         spc: false,
         barcode: barcode,
         color: null
     };
 
-    if (
-        barcode.startsWith("8804007") ||
-        barcode.startsWith("880939312") ||
-        barcode.startsWith("8801068")
-    ) {
-        returnStrings.manu = "SPC삼립";
-        returnStrings.spc = true;
-        returnStrings.color = "#30B3E7";
-        return returnStrings;
-    } else if (
-        barcode.startsWith("880928863")
-    ) {
-        returnStrings.manu = "BR코리아";
-        returnStrings.spc = true;
-        returnStrings.color = "#DB5B9B";
-        return returnStrings;
-    } else if (
-        barcode.startsWith("880969023")
-    ) {
-        returnStrings.manu = "파리크라상";
-        returnStrings.spc = true;
-        returnStrings.color = "#4063A0";
-        return returnStrings;
-    } else {
-        return returnStrings;
+    for(const index of Object.keys(manufacturers.indexes)) {
+        if(barcode.startsWith(index)) {
+            const manu = manufacturers[manufacturers.indexes[index]];
+            returnStrings.manu = manu.name;
+            returnStrings.spc = manu.spc;
+            returnStrings.color = manu.color;
+        }
     }
+
+    return returnStrings;
 }

--- a/src/routes/api/+server.js
+++ b/src/routes/api/+server.js
@@ -14,6 +14,7 @@ export function isSpcProduct(barcode) {
             returnStrings.manu = manu.name;
             returnStrings.spc = manu.spc;
             returnStrings.color = manu.color;
+            break;
         }
     }
 

--- a/src/routes/api/manufacturers.json
+++ b/src/routes/api/manufacturers.json
@@ -1,0 +1,25 @@
+{
+  "indexes": {
+    "8804007": "spc-samlip",
+    "880939312": "spc-samlip",
+    "8801068": "spc-samlip",
+    "880928863": "br-korea",
+    "880969023": "paris-croissant"
+  },
+
+  "spc-samlip": {
+    "name": "SPC삼립",
+    "color": "#30B3E7",
+    "spc": true
+  },
+  "br-korea": {
+    "name": "BR코리아",
+    "color": "#DB5B9B",
+    "spc": true
+  },
+  "paris-croissant": {
+    "name": "파리크라상",
+    "color": "#4063A0",
+    "spc": true
+  }
+}


### PR DESCRIPTION
업체별 바코드 prefix를 JSON 파일에 담고, 그 파일을 불러와서 업체 판별을 할 수 있도록 수정하였습니다.

JSON 파일에서 바코드 prefix는 `indexes` 오브젝트 안에 `[prefix]: [id]` 형태로 추가하고, 루트 오브젝트에 키가 `[id]`인 `name`, `color`, `spc`가 담긴 오브젝트를 추가하는 것으로 업체를 쉽게 추가할 수 있습니다.

이 풀리퀘로 이슈 #2 의 첫 번째 Task가 해결될 것 같네요.